### PR TITLE
tournamentTable

### DIFF
--- a/src/components/accounts/index.tsx
+++ b/src/components/accounts/index.tsx
@@ -6,10 +6,8 @@ import { ExportIcon } from '../icons/accounts/export-icon'
 import { InfoIcon } from '../icons/accounts/info-icon'
 import { TrashIcon } from '../icons/accounts/trash-icon'
 import { HouseIcon } from '../icons/breadcrumb/house-icon'
-import { UsersIcon } from '../icons/breadcrumb/users-icon'
 import { SettingsIcon } from '../icons/sidebar/settings-icon'
 import { TableWrapper } from '../tournamentTable/table'
-import { AddUser } from './add-user'
 
 export const Accounts = () => {
   return (

--- a/src/components/tournamentTable/render-cell.tsx
+++ b/src/components/tournamentTable/render-cell.tsx
@@ -4,6 +4,7 @@ import { DeleteIcon } from '../icons/table/delete-icon'
 import { EditIcon } from '../icons/table/edit-icon'
 import { EyeIcon } from '../icons/table/eye-icon'
 import { tournaments } from './data'
+import Link from 'next/link'
 
 interface Props {
   tournament: (typeof tournaments)[number]
@@ -55,10 +56,18 @@ export const RenderCell = ({ tournament, columnKey }: Props) => {
             </Tooltip>
           </div>
           <div>
-            <Tooltip content="Edit user" color="secondary">
-              <button onClick={() => console.log('Edit user', tournament.id)}>
-                <EditIcon size={20} fill="#979797" />
-              </button>
+            <Tooltip content="Edit tournament" color="secondary">
+              <Link
+                href={{
+                  pathname: '/tourneys/editTournament',
+                  query: { id: tournament.id },
+                }}
+                as={`/edit/${tournament.id}`}
+              >
+                <button>
+                  <EditIcon size={20} fill="#979797" />
+                </button>
+              </Link>
             </Tooltip>
           </div>
           <div></div>

--- a/src/pages/tourneys/editTournament.tsx
+++ b/src/pages/tourneys/editTournament.tsx
@@ -1,0 +1,112 @@
+'use client'
+import React from 'react'
+import { useRouter } from 'next/router'
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react'
+
+const tournamentData = [
+  {
+    position: '1.',
+    name: 'Emil',
+    wins: '8',
+    tie: '0',
+    loss: '1',
+    games: '9',
+    points: '24',
+  },
+  {
+    position: '2.',
+    name: 'Joni',
+    wins: '6',
+    tie: '1',
+    loss: '1',
+    games: '8',
+    points: '19',
+  },
+  {
+    position: '3.',
+    name: 'Eetu',
+    wins: '5',
+    tie: '0',
+    loss: '3',
+    games: '8',
+    points: '15',
+  },
+  {
+    position: '4.',
+    name: 'Otto',
+    wins: '4',
+    tie: '2',
+    loss: '4',
+    games: '10',
+    points: '14',
+  },
+  {
+    position: '5.',
+    name: 'Ilkka',
+    wins: '3',
+    tie: '3',
+    loss: '2',
+    games: '8',
+    points: '12',
+  },
+  {
+    position: '6.',
+    name: 'Simo',
+    wins: '3',
+    tie: '1',
+    loss: '4',
+    games: '8',
+    points: '10',
+  },
+  {
+    position: '7.',
+    name: 'Yrjö',
+    wins: '2',
+    tie: '0',
+    loss: '6',
+    games: '8',
+    points: '6',
+  },
+  {
+    position: '8.',
+    name: 'Surkimus',
+    wins: '0',
+    tie: '0',
+    loss: '8',
+    games: '8',
+    points: '0',
+  },
+]
+
+export default function EditTournament() {
+  const router = useRouter()
+  const { id } = router.query
+  console.log(id, 'id passing to editTournaments')
+
+  return (
+    <Table aria-label="Example static collection table">
+      <TableHeader>
+        <TableColumn>POSITION</TableColumn>
+        <TableColumn>NAME</TableColumn>
+        <TableColumn>WINS</TableColumn>
+        <TableColumn>TIE</TableColumn>
+        <TableColumn>LOSS</TableColumn>
+        <TableColumn>GAMES</TableColumn>
+        <TableColumn>POINTS</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {tournamentData.map((data, index) => (
+          <TableRow key={index}>
+            <TableCell>{data.position}</TableCell>
+            <TableCell>{data.name}</TableCell>
+            <TableCell>{data.wins}</TableCell>
+            <TableCell>{data.tie}</TableCell>
+            <TableCell>{data.loss}</TableCell>
+            <TableCell>{data.games}</TableCell>
+            <TableCell>{data.points}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/src/pages/tourneys/new.tsx
+++ b/src/pages/tourneys/new.tsx
@@ -8,13 +8,17 @@ import {
   DropdownTrigger,
   DropdownMenu,
   DropdownItem,
+  Link,
 } from '@nextui-org/react'
 import { gql, useMutation } from '@apollo/client'
 import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useQuery } from '@apollo/client'
 
 const newTourneyMutation = gql`
   mutation CreateTournament($input: CreateTournamentInput!) {
     createTournament(input: $input) {
+      id
       name
 
       rules {
@@ -38,8 +42,9 @@ function TourneysNew() {
   const [hiddenField, setHiddenField] = useState('hidden')
   const [mutateFunction, { data, loading, error }] = useMutation(newTourneyMutation)
   const { data: session } = useSession()
+  const router = useRouter()
 
-  const newTourney = (e: React.FormEvent<HTMLFormElement>) => {
+  const newTourney = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const form = e.currentTarget
     const tourneyName = (form[0] as HTMLInputElement).value
@@ -55,19 +60,22 @@ function TourneysNew() {
       ruleset = selectedKeys.values().next().value
     }
 
-    mutateFunction({
+    const result = await mutateFunction({
       variables: {
         input: {
           name: tourneyName,
           rules: ['65106775553dac66bcfac032'],
           date: endDate,
           maxPlayers: maxPlayers,
-          players: session?.user?.id,
+          players: [],
           admin: session?.user?.id,
           invitationOnly: invitationOnly,
         },
       },
     })
+
+    const createdTournamentId = result.data.createTournament.id
+    router.push(`/tourneys/editTournament?id=${createdTournamentId}`)
   }
 
   const chooseGameMode = React.useMemo(() => {

--- a/src/types/Tournament.ts
+++ b/src/types/Tournament.ts
@@ -1,5 +1,3 @@
-import { Tournament } from '@/types/Tournament'
-
 import { Types } from 'mongoose'
 import { Document } from 'mongoose'
 


### PR DESCRIPTION
The raw start of editTournament page added with test data, after tournament is created redirect to editTournament page and send id of the tournament. Edit button in tournaments view and main view now directs to editTournament page. Removed add admin as a player to tournament on creation because it might be very well that the admin wont be a player. All player adding will be done after the tournament is created. Some other minor things here and there. Changes to files new.tsx and render-cell.tsx, so Eetu and Emil headsup..
![kuva](https://github.com/rocksanen/maketournaments/assets/50525635/6a1cb6e3-7bd7-4e58-840d-3d50f1f71b82)
